### PR TITLE
Add next_sequence class method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ s2 = Sequenced.create
 s2.id #=> 2 # and so on
 ```
 
+You can also have any per model sequence without need to create given model's objects:
+
+```ruby
+class Sequenced
+	include Mongoid::Document
+	include Mongoid::Sequence
+end
+
+Sequenced.next_sequence('some_name_1') #=> 1
+Sequenced.next_sequence('some_name_1') #=> 2
+Sequenced.next_sequence('some_name_2') #=> 1
+```
+
 ## Consistency
 
 Mongoid::Sequence uses the atomic [findAndModify](http://www.mongodb.org/display/DOCS/findAndModify+Command) command, so you shouldn't have to worry about the sequence's consistency.

--- a/lib/mongoid-sequence2/sequence.rb
+++ b/lib/mongoid-sequence2/sequence.rb
@@ -17,12 +17,16 @@ module Mongoid
         self.sequence_fields ||= []
         self.sequence_fields << fieldname
       end
+
+      def next_sequence(field)
+        Sequences.get_next_sequence(self.name.underscore, field)
+      end
     end
 
     def set_sequence
       if self.class.sequence_fields.present?
         self.class.sequence_fields.each do |f|
-          self[f] = Sequences.get_next_sequence(self.class.name.underscore, f)
+          self[f] = self.class.next_sequence(f)
         end
       end
     end

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -5,4 +5,9 @@ class ReferenceTest < BaseTest
     s = ThirdSequencedModel.create(auto_increment: 1)
     assert_equal s.auto_increment, 1
   end
+
+  def test_next_sequence
+    assert_equal ThirdSequencedModel.next_sequence('test_field'), 1
+    assert_equal ThirdSequencedModel.next_sequence('test_field'), 2
+  end
 end


### PR DESCRIPTION
This adds `next_sequence` class method, which allows to have any per model sequence, without need to create given model's objects. 
